### PR TITLE
Cast to fix compile error in C++ builds

### DIFF
--- a/include/bgen/bstring.h
+++ b/include/bgen/bstring.h
@@ -27,7 +27,7 @@ struct bgen_string
  */
 static inline struct bgen_string const* bgen_string_create(char const* data, size_t length)
 {
-    struct bgen_string* str = malloc(sizeof(struct bgen_string));
+    struct bgen_string* str = (struct bgen_string*)malloc(sizeof(struct bgen_string));
     str->data = data;
     str->length = length;
     return str;


### PR DESCRIPTION
When including bgen.h in C++ code the compiler complains about implicit casts from void*. These implicit casts are fine in .c files, since the C compiler is building those. The alternative to making the cast explicit would be to compile all C++ translation units with -fpermissive, if they include bgen.h (but this can supress useful compiler errors).

I considered making a unit test for this (which would fail to compile if a header file added such an implicit cast in the future), but that would add a dependency on having a C++ compiler to build the library.